### PR TITLE
PR Summary: Refactor Subscription Management

### DIFF
--- a/app/models/billing.py
+++ b/app/models/billing.py
@@ -67,7 +67,10 @@ class BillingPortalResponse(BaseModel):
 
 
 class SubscriptionCancellationRequest(BaseModel):
-    """Request model for cancelling a subscription."""
+    """Request model for cancelling a subscription.
+       subscription_id: ID of the subscription to cancel
+       cancel_at_period_end: If True, cancels at period end. If False, cancels immediately.
+    """
 
     subscription_id: str = Field(..., description="The ID of the subscription to cancel")
     cancel_at_period_end: bool = Field(

--- a/app/models/billing.py
+++ b/app/models/billing.py
@@ -66,6 +66,22 @@ class BillingPortalResponse(BaseModel):
     url: str = Field(..., description="URL to redirect to Stripe customer billing portal")
 
 
+class SubscriptionCancellationRequest(BaseModel):
+    """Request model for cancelling a subscription."""
+
+    subscription_id: str = Field(..., description="The ID of the subscription to cancel")
+    cancel_at_period_end: bool = Field(
+        True,
+        description="If True, cancels at period end. If False, cancels immediately.",
+    )
+
+
+class SubscriptionReactivationRequest(BaseModel):
+    """Request model for reactivating a subscription."""
+
+    subscription_id: str = Field(..., description="The ID of the subscription to reactivate")
+
+
 class SubscriptionReactivationResponse(BaseModel):
     """Response model for subscription reactivation."""
     success: bool = Field(..., description="Whether reactivation was successful")

--- a/app/models/meal.py
+++ b/app/models/meal.py
@@ -150,7 +150,8 @@ class ServingUnitEnum(str, Enum):
     PLATE = "plate"
     SCOOP = "scoop"
     SLICE = "slice"
-    MILL = "mill"
+    BOWL = "bowl"
+    ML = "ml"
 
 
 class LogMealRequest(BaseModel):

--- a/app/services/meal_service.py
+++ b/app/services/meal_service.py
@@ -6,6 +6,8 @@ import logging
 from typing import Dict, Any, List, Optional
 from collections import defaultdict
 from datetime import datetime, date, time, timedelta
+import calendar
+from dateutil.relativedelta import relativedelta
 
 import httpx
 from fastapi import HTTPException, status
@@ -811,20 +813,18 @@ class MealService:
         )
 
     async def _get_quarterly_progress(self, user_id: str, target_macros: MacroNutrients) -> ProgressSummary:
-        """Get progress for last 3 complete months."""
-        import calendar
+        """Get progress for the current and previous 2 months."""
         
         today = date.today()
         months_data = []
         
-        for i in range(3, 0, -1):  # 3, 2, 1 months ago
-            if today.month - i > 0:
-                target_month = today.month - i
-                target_year = today.year
-            else:
-                target_month = today.month - i + 12
-                target_year = today.year - 1
-                
+        # Loop for current month and 2 previous months (2, 1, 0 months ago)
+        for i in range(2, -1, -1):
+            # Calculate the target month by subtracting `i` months from today
+            target_date = today - relativedelta(months=i)
+            target_month = target_date.month
+            target_year = target_date.year
+            
             month_start = date(target_year, target_month, 1)
             month_end = date(target_year, target_month, calendar.monthrange(target_year, target_month)[1])
             
@@ -837,20 +837,18 @@ class MealService:
         return await self._get_monthly_aggregation(user_id, target_macros, months_data, "3m")
 
     async def _get_six_month_progress(self, user_id: str, target_macros: MacroNutrients) -> ProgressSummary:
-        """Get progress for last 6 complete months."""
-        import calendar
+        """Get progress for the current and previous 5 months."""
         
         today = date.today()
         months_data = []
         
-        for i in range(6, 0, -1):  # 6, 5, 4, 3, 2, 1 months ago
-            if today.month - i > 0:
-                target_month = today.month - i
-                target_year = today.year
-            else:
-                target_month = today.month - i + 12
-                target_year = today.year - 1
-                
+        # Loop for current month and 5 previous months (5, 4, 3, 2, 1, 0 months ago)
+        for i in range(5, -1, -1):
+            # Calculate the target month by subtracting `i` months from today
+            target_date = today - relativedelta(months=i)
+            target_month = target_date.month
+            target_year = target_date.year
+            
             month_start = date(target_year, target_month, 1)
             month_end = date(target_year, target_month, calendar.monthrange(target_year, target_month)[1])
             

--- a/app/services/stripe_service.py
+++ b/app/services/stripe_service.py
@@ -305,40 +305,22 @@ class StripeService:
             raise StripeServiceError(f"Error updating user subscription: {str(e)}")
 
     async def cancel_user_subscription(
-        self, user_id: str, cancel_at_period_end: bool = True
+        self, subscription_id: str, cancel_at_period_end: bool = True
     ) -> stripe.Subscription:
-        """Cancel user's Stripe subscription.
+        """Cancel a Stripe subscription by its ID.
 
         Args:
-            user_id: User identifier
-            cancel_at_period_end: Whether to cancel at billing period end
+            subscription_id: The ID of the Stripe subscription to cancel.
+            cancel_at_period_end: Whether to cancel at billing period end.
 
         Returns:
-            Updated Stripe Subscription object
+            Updated Stripe Subscription object.
 
         Raises:
-            StripeServiceError: When subscription not found or cancellation fails
+            StripeServiceError: When subscription not found or cancellation fails.
         """
         try:
-            logger.info(f"Cancelling subscription for user: {user_id}")
-            if not BaseDatabaseService.subclasses:
-                raise StripeServiceError("No database service implementation available")
-
-            # fetch stripe subscription id for user if it exists
-            response = BaseDatabaseService.subclasses[0]().select_data(
-                table_name="user_profiles", cols={"id": user_id}
-            )
-            if response and isinstance(response, List):
-                subscription_id = response[0]["stripe_subscription_id"]
-            elif response:
-                subscription_id = response
-
-            else:
-                subscription_id = None
-
-            if not subscription_id:
-                raise StripeServiceError("Subscription id not found for customer")
-
+            logger.info(f"Cancelling subscription: {subscription_id}")
 
             if cancel_at_period_end:
                 sub = stripe.Subscription.modify(
@@ -350,83 +332,70 @@ class StripeService:
 
             return sub
         except stripe.StripeError as e:
-            logger.error(f"Stripe error: {str(e)}")
+            logger.error(f"Stripe error cancelling subscription {subscription_id}: {str(e)}")
             raise StripeServiceError(f"Error cancelling subscription: {str(e)}")
         except Exception as e:
             logger.error(
-                f"Failed to cancel subscription for user: {user_id} with error{str(e)}"
+                f"Failed to cancel subscription {subscription_id} with error: {str(e)}"
             )
             raise StripeServiceError("Unexpected error while cancelling subscription")
 
-    async def reactivate_user_subscription(self, user_id: str) -> stripe.Subscription:
-        """Reactivate user's subscription that was set to cancel at period end.
+    async def reactivate_user_subscription(self, subscription_id: str) -> stripe.Subscription:
+        """Reactivate a subscription that was set to cancel at period end.
 
         Args:
-            user_id: User identifier
+            subscription_id: The ID of the subscription to reactivate.
 
         Returns:
-            Updated Stripe Subscription object
+            Updated Stripe Subscription object.
 
         Raises:
-            StripeServiceError: When subscription not found, not eligible for reactivation, or reactivation fails
+            StripeServiceError: When subscription not found, not eligible for reactivation, or reactivation fails.
         """
         try:
-            logger.info(f"Reactivating subscription for user: {user_id}")
+            logger.info(f"Reactivating subscription: {subscription_id}")
 
-            if not BaseDatabaseService.subclasses:
-                raise StripeServiceError("No database service implementation available")
-
-            # Get subscription details first
-            subscription_details = await self.get_subscription_details(user_id)
-
-            if not subscription_details.get("has_subscription"):
-                raise StripeServiceError("No subscription found for user")
-
-            subscription_id = subscription_details.get("subscription_id")
-            if not subscription_id:
-                raise StripeServiceError("Subscription ID not found")
+            # Get subscription details from Stripe
+            subscription = stripe.Subscription.retrieve(subscription_id)
 
             # Check if subscription is eligible for reactivation
-            if not subscription_details.get("cancel_at_period_end"):
+            if not subscription.cancel_at_period_end:
                 raise StripeServiceError(
                     "Subscription is not set to cancel - no reactivation needed"
                 )
 
             # Check if subscription is still active (hasn't ended yet)
-            status = subscription_details.get("status")
-            if status not in ["active", "trialing"]:
+            if subscription.status not in ["active", "trialing"]:
                 raise StripeServiceError(
-                    f"Subscription cannot be reactivated - current status: {status}"
+                    f"Subscription cannot be reactivated - current status: {subscription.status}"
                 )
 
             # Check if we're still within the current period
-
-            current_period_end = subscription_details.get("current_period_end")
-            if current_period_end and datetime.now(
-                timezone.utc
-            ) >= current_period_end.replace(tzinfo=timezone.utc):
+            if datetime.now(timezone.utc) >= datetime.fromtimestamp(
+                subscription.current_period_end, tz=timezone.utc
+            ):
                 raise StripeServiceError(
                     "Subscription period has already ended - cannot reactivate"
                 )
 
             # Reactivate the subscription
-            subscription = stripe.Subscription.modify(
+            reactivated_subscription = stripe.Subscription.modify(
                 subscription_id, cancel_at_period_end=False
             )
 
             logger.info(
-                f"Successfully reactivated subscription {subscription_id} for user {user_id}"
+                f"Successfully reactivated subscription {subscription_id}"
             )
-            return subscription
+            return reactivated_subscription
 
         except stripe.StripeError as e:
-            logger.error(f"Stripe error: {str(e)}")
+            logger.error(f"Stripe error reactivating subscription {subscription_id}: {str(e)}")
             raise StripeServiceError(f"Error reactivating subscription: {str(e)}")
         except StripeServiceError:
             raise
         except Exception as e:
             logger.error(
-                f"Failed to reactivate subscription for user: {user_id} with error: {str(e)}"
+                f"Failed to reactivate subscription {subscription_id} with error: {str(e)}"
             )
             raise StripeServiceError("Unexpected error while reactivating subscription")
 


### PR DESCRIPTION

### Description
This pull request introduces significant improvements to the billing and subscription management system and enhances the user-facing progress summary feature.

The subscription cancellation and reactivation endpoints have been refactored to operate directly on a `subscription_id` provided in the request body. This change increases the flexibility of the API, decouples the action from the user's immediate session data, and aligns with standard RESTful practices. For security, all operations still verify that the subscription belongs to the authenticated user before proceeding.

Additionally, the date range logic for the 3-month and 6-month progress summaries has been updated to be inclusive of the current month. This provides users with a more relevant and up-to-date view of their nutritional progress. The changes also include several critical bug fixes that were identified during the refactoring process.

### Changes Made

**Billing & Subscription Management**

*   **Refactored Cancellation Endpoint (`/cancel`):**
    *   The endpoint now accepts a `DELETE` request with a `SubscriptionCancellationRequest` body containing the `subscription_id` and a `cancel_at_period_end` boolean.
    *   This removes the need for a query parameter and streamlines the process.
*   **Refactored Reactivation Endpoint (`/reactivate-subscription`):**
    *   The endpoint now accepts a `POST` request with a `SubscriptionReactivationRequest` body containing the `subscription_id`.
*   **Updated Stripe Service:**
    *   The `cancel_user_subscription` and `reactivate_user_subscription` methods in `stripe_service.py` were modified to accept a `subscription_id` directly.
*   **New Pydantic Models:**
    *   Added `SubscriptionCancellationRequest` and `SubscriptionReactivationRequest` to `app/models/billing.py` to define the new request bodies.
*   **Security:**
    *   Both cancellation and reactivation endpoints now verify that the `subscription_id` from the request body belongs to the authenticated user before performing any action.

**Misc**

*   **Adjusted 3-Month Summary:** The summary now includes the current month and the two previous months.
*   **Adjusted 6-Month Summary:** The summary now includes the current month and the five previous months.
*   Added `calendar` and `relativedelta` imports to `app/services/meal_service.py` to support the new date logic.
*   Resolved a `TypeError` in `get_meals_by_date_range` where a `datetime` object was being treated as an iterable.
*   Corrected the construction of `httpx` query parameters to properly filter by a date range, resolving a PostgREST parsing error.