### PR TITLE
Implement Match Percentage Logic in Meal Finder

### DIFF
--- a/app/models/meal.py
+++ b/app/models/meal.py
@@ -94,12 +94,19 @@ class MealSuggestion(BaseModel):
         description: Brief description of the meal
         macros: Estimated macro nutrients
         restaurant: Source restaurant information
+        match_score: Match score (0-100%) reflecting alignment with user's macro requirements and dietary preferences
     """
 
     name: str
     description: str
     macros: MacroNutrients
     restaurant: Restaurant
+    match_score: int = Field(
+        ..., 
+        ge=0, 
+        le=100, 
+        description="Match score (0-100%) reflecting alignment with user's macro requirements and dietary preferences. Lower scores for meals that ignore dietary restrictions or have significant macro overages/shortages."
+    )
 
     model_config = {
         "json_schema_extra": {
@@ -111,6 +118,7 @@ class MealSuggestion(BaseModel):
                     "name": "Healthy Bites",
                     "location": "123 Main St, Finchley",
                 },
+                "match_score": 85
             }
         }
     }

--- a/app/services/meal_llm_service.py
+++ b/app/services/meal_llm_service.py
@@ -177,12 +177,19 @@ class MealLLMService(BaseLLMService):
                     2. Brief description
                     3. Estimated macros (calories, protein, carbs, fat) — note these can be approximate
                     4. Restaurant name and location
+                    5. Match score (0-100%) - Calculate this based on:
+                       - How closely the meal's macros align with the target macros (higher score for closer matches)
+                       - Adherence to dietary restrictions (meals that violate restrictions should receive very low scores 0-30%)
+                       - Compatibility with dietary preferences (meals that align well should get higher scores)
+                       - Account for macro overages and shortages (significant overages or shortages should reduce the score)
+                       - Perfect matches should score 90-100%, good matches 70-89%, fair matches 50-69%, poor matches 30-49%, incompatible meals 0-29%
 
                     Format your response as a JSON object with a "meals" property containing an array of meal objects. Each meal object should include:
                     - name (string)
                     - description (string)
                     - macros (object) with numeric values for "calories", "protein", "carbs", "fat"
-                    - restaurant (object) with "name" and "location" properties"""
+                    - restaurant (object) with "name" and "location" properties
+                    - match_score (integer from 0-100)"""
         
         if self.restaurants:
             prompt += """
@@ -192,6 +199,7 @@ class MealLLMService(BaseLLMService):
                     Only suggest restaurants that exist in {request.location}."""
         
         prompt += f"""
+                    
                     Example format (do not use these values, please suggest real meals (between 5 and 8 meals) and check if these name and location exist near {request.location} else do not return in json):
                     ```json
                     {{
@@ -208,7 +216,8 @@ class MealLLMService(BaseLLMService):
                         "restaurant": {{
                             "name": "Lorem Ipsum",
                             "location": "123 Main St, Finchley, N3 3EB"
-                        }}
+                        }},
+                        "match_score": 85
                         }}
                     ]
                     }}


### PR DESCRIPTION
## Summary
Added a `match_score` field (0-100%) to meal suggestions that reflects alignment with user's macro requirements and dietary preferences/restrictions. Meals that completely ignore dietary preferences receive low scores, and the system accounts for overages and shortages in individual macros.

## Changes Made
- **`app/models/meal.py`**: Added `match_score` integer field (0-100) to `MealSuggestion` model with validation
- **`app/services/meal_llm_service.py`**: Updated `_build_prompt()` method to include detailed scoring instructions for the AI:
  - Score based on macro alignment with targets
  - Penalize meals violating dietary restrictions (0-30% scores)
  - Account for macro overages/shortages
  - Scoring scale: 90-100% perfect, 70-89% good, 50-69% fair, 30-49% poor, 0-29% incompatible